### PR TITLE
[DOCS] Fix rendering for configuration

### DIFF
--- a/Documentation/Configuration/General.rst
+++ b/Documentation/Configuration/General.rst
@@ -34,6 +34,7 @@ Use Powermail Cleaner in a disabled state
 
 If you want to prepare your existing forms, you need to prevent, that all warnings in the Frontend are active. There are
 two options to achieve this:
+
 * Do not include the TypoScript Record "Powermail Cleaner Template"
 * Disable the settings via TypoScript (see example below) - this is recommended if you want to activate the functionality parially.
 


### PR DESCRIPTION
Lists must be preceded and followed by a blank line.

-----

_The following is extra information, not in commit message:_

This is also a problem if file is rendered by GitHub, see https://github.com/in2code-de/powermail_cleaner/blob/v12/Documentation/Configuration/General.rst


Screenshot: 

-----

![image](https://github.com/user-attachments/assets/0583c560-3e6e-4a8c-b9dd-a52bcafd9a89)

-----

Code:

```
If you want to prepare your existing forms, you need to prevent, that all warnings in the Frontend are active. There are
two options to achieve this:
* Do not include the TypoScript Record "Powermail Cleaner Template"
* Disable the settings via TypoScript (see example below) - this is recommended if you want to activate the functionality parially.
```


It used to also be a problem, if documentation was rendered on docs server, but the rendering
was changed so I don't know at this point. 

see also: https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/Reference/ReStructuredText/Lists/BulletLists.html#bullet-lists-unordered-lists

> Lists should have an empty line before and after