### PR TITLE
[DOCS] Fix configuration code snippet

### DIFF
--- a/Documentation/Configuration/General.rst
+++ b/Documentation/Configuration/General.rst
@@ -39,23 +39,7 @@ two options to achieve this:
 
 ..  code-block:: typoscript
 
-    plugin.tx_powermail {
-        view {
-            templateRootPaths {
-                10 = EXT:powermail_cleaner/Resources/Private/Templates/
-            }
-
-            partialRootPaths {
-                10 = EXT:powermail_cleaner/Resources/Private/Partials/
-            }
-
-            layoutRootPaths {
-                10 = EXT:powermail_cleaner/Resources/Private/Layouts/
-            }
-        }
-        settings.setup.powermail_cleaner_enabled = 1
-    }
-
+    plugin.tx_powermail.settings.setup.powermail_cleaner_enabled = 0
 
 ..  _configuration_typical:
 


### PR DESCRIPTION
In order to deactivate powermail_cleaner, the setting must be set to 0.

Also, we do not need to repeat the code in the default TypoScript setup.