### PR TITLE
Change language label in PluginPreview.html

### DIFF
--- a/Resources/Private/Templates/PluginPreview.html
+++ b/Resources/Private/Templates/PluginPreview.html
@@ -31,7 +31,7 @@
                 <f:defaultCase>
                     <div class="mt-2">
                         <f:be.infobox title="{f:translate(key: 'LLL:EXT:powermail_cleaner/Resources/Private/Language/locallang_db.xlf:pluginInfo.noCleanerConfiguration.title', default: 'Configuration error')}" state="2">
-                            {f:translate(key: 'LLL:EXT:powermail_cleaner/Resources/Private/Language/locallang_db.xlf:pluginInfo.noCleanerConfiguration.wrongConfiguration', default: 'Wrong plugin configuration')}
+                            {f:translate(key: 'LLL:EXT:powermail_cleaner/Resources/Private/Language/locallang_db.xlf:pluginInfo.noCleanerConfiguration.message', default: 'Powermail Cleaner configuration is not properly set. Please check plugin configuration.')}
                         </f:be.infobox>
                     </div>
                 </f:defaultCase>


### PR DESCRIPTION
An undefined lanugage label was used.

Resolves: #7

-----

Note: it might make more sense to use diffent language labels for backend and frontend