### PR TITLE
[BUGFIX] Change TCA of mail plugin field to fetch less records

### DIFF
--- a/Configuration/TCA/Overrides/tx_powermail_domain_model_mail.php
+++ b/Configuration/TCA/Overrides/tx_powermail_domain_model_mail.php
@@ -22,7 +22,8 @@ $columns = [
             'type' => 'select',
             'renderType' => 'selectSingle',
             'foreign_table' => 'tt_content',
-            'foreign_table_where' => 'and tt_content.deleted = 0 order by tt_content.header',
+            // only fetch selected record since field is readOnly and other options will not be selectable anyway
+            'foreign_table_where' => 'and tt_content.deleted = 0 and tt_content.uid=###REC_FIELD_plugin###',
             'readOnly' => true,
         ],
     ],


### PR DESCRIPTION
Change tx_powermail_domain_model_mail.plugin TCA configuration so that only the selected related tt_content record is fetched.

The previous TCA configuration for tx_powermail_domain_model_mail.plugin resulted in DB queries with large result sets on large sites since all tt_content records were returned (including bodytext field). A lot of this was not necessary as the non-plugin records were fetched as well. Additionally, the field is readOnly, so the results were not displayed.

If the field is to be changed to non-readOnly, the query could be restricted to fetch only plugin fields.

Resolves: #15

----

_based on v12 branch since this is the default._