### PR TITLE
[TASK] Add checks and tests for GitHub workflows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,53 @@
+# Unix-style newlines with a newline ending every file
+# copied from in2code/powermail
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# TS/JS-Files
+[*.{ts,js}]
+indent_size = 2
+
+# composer.json
+# composer.json currently deviates from default by using 2 spaces indents
+[composer.json]
+indent_size = 2
+
+# JSON-Files
+[*.json]
+indent_style = tab
+
+# ReST-Files (TYPO3 core convention is no longer 3 spaces, it is 4 spaces)
+[*.{rst,rst.txt}]
+indent_size = 4
+max_line_length = 80
+
+# YAML-Files
+[*.{yaml,yml}]
+indent_size = 2
+
+# package.json
+# .travis.yml
+[{package.json,.travis.yml}]
+indent_size = 2
+
+# TypoScript
+[*.{typoscript,tsconfig}]
+indent_size = 2
+
+# XLF-Files
+[*.xlf]
+indent_style = tab
+
+# SQL-Files
+[*.sql]
+indent_style = tab
+indent_size = 2
+
+# .htaccess
+[{_.htaccess,.htaccess}]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 *.gz filter=lfs diff=lfs merge=lfs -text
+/.editorconfig export-ignore
+/.github export-ignore
+/.project export-ignore
+/Tests  export-ignore

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -1,0 +1,101 @@
+# currently only testing with v12 and supported PHP versions for v12 (8.1-8.4)
+# todo
+# - execute "composer fix:php:cs" and uncomment "php-cs-fixer" job
+name: testing
+on:
+  push:
+    branches-ignore:
+      - 'l10n_*'
+  pull_request:
+    branches-ignore:
+      - 'l10n_*'
+
+jobs:
+  php-lint:
+    name: "PHP linter"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+      - name: "Install PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "${{ matrix.php-version }}"
+          coverage: none
+          tools: composer:v2
+      - name: "Run PHP lint"
+        run: "composer test:php:lint"
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - 8.1
+          - 8.2
+          - 8.3
+          - 8.4
+  typoscript-lint:
+    name: "TypoScript linter"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+      - name: "Run TypoScript lint"
+        uses: TYPO3-Continuous-Integration/TYPO3-CI-Typoscript-Lint@v1
+        with:
+          files: "./Configuration"
+          config_file: ".project/tests/typoscript-lint.yml"
+  #php-cs-fixer:
+  #  name: "PHP CS Fixer"
+  #  runs-on: ubuntu-24.04
+  #  needs: php-lint
+  #  steps:
+  #    - name: "Checkout"
+  #      uses: actions/checkout@v4
+  #    - name: "Install PHP"
+  #      uses: shivammathur/setup-php@v2
+  #      with:
+  #        php-version: 8.1
+  #    - name: "Composer Install"
+  #      run: "composer install"
+  #    - name: "Run PHP CS Fixer"
+  #      run: "composer test:php:cs"
+  phpstan:
+    name: "PHPstan"
+    runs-on: ubuntu-24.04
+    needs: php-lint
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+      - name: "Install PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+      - name: "Composer Install"
+        run: "composer install"
+      - name: "Run PHPstan"
+        run: "composer test:php:phpstan"
+  #unit-tests:
+  #  name: "PHP Unit Tests"
+  #  runs-on: ubuntu-24.04
+  #  needs: php-lint
+  #  steps:
+  #    - name: Checkout
+  #      uses: actions/checkout@v4
+  #    - name: "Install PHP"
+  #      uses: shivammathur/setup-php@v2
+  #      with:
+  #        php-version: "${{ matrix.php-version }}"
+  #        coverage: none
+  #        tools: composer:v2
+  #    - name: "Composer Install"
+  #      run: "composer install"
+  #    - name: "Run Unit Tests"
+  #      run: "composer test:unit"
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - 8.1
+          - 8.2
+          - 8.3
+          - 8.4

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -1,6 +1,7 @@
 # currently only testing with v12 and supported PHP versions for v12 (8.1-8.4)
 # todo
 # - execute "composer fix:php:cs" and uncomment "php-cs-fixer" job
+# - fix TypoScript linter and uncomment jog
 name: testing
 on:
   push:
@@ -33,17 +34,17 @@ jobs:
           - 8.2
           - 8.3
           - 8.4
-  typoscript-lint:
-    name: "TypoScript linter"
-    runs-on: ubuntu-24.04
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-      - name: "Run TypoScript lint"
-        uses: TYPO3-Continuous-Integration/TYPO3-CI-Typoscript-Lint@v1
-        with:
-          files: "./Configuration"
-          config_file: ".project/tests/typoscript-lint.yml"
+  #typoscript-lint:
+  #  name: "TypoScript linter"
+  #  runs-on: ubuntu-24.04
+  #  steps:
+  #    - name: "Checkout"
+  #      uses: actions/checkout@v4
+  #    - name: "Run TypoScript lint"
+  #      uses: TYPO3-Continuous-Integration/TYPO3-CI-Typoscript-Lint@v1
+  #      with:
+  #        files: "./Configuration"
+  #        config_file: ".project/tests/typoscript-lint.yml"
   #php-cs-fixer:
   #  name: "PHP CS Fixer"
   #  runs-on: ubuntu-24.04

--- a/.project/tests/.php-cs-fixer.php
+++ b/.project/tests/.php-cs-fixer.php
@@ -1,0 +1,111 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+/**
+ * This file represents the configuration for Code Sniffing PSR-2-related
+ * automatic checks of coding guidelines
+ * Install @fabpot's great php-cs-fixer tool via
+ *
+ *  $ composer global require friendsofphp/php-cs-fixer
+ *
+ * And then simply run
+ *
+ *  $ php-cs-fixer fix --config ../Build/.php_cs
+ *
+ * inside the TYPO3 directory. Warning: This may take up to 10 minutes.
+ *
+ * For more information read:
+ *     https://www.php-fig.org/psr/psr-2/
+ *     https://cs.sensiolabs.org
+ */
+if (PHP_SAPI !== 'cli') {
+    die('This script supports command line usage only. Please check your command.');
+}
+// Define in which folders to search and which folders to exclude
+// Exclude some directories that are excluded by Git anyways to speed up the sniffing
+$finder = PhpCsFixer\Finder::create()
+    ->in(
+        [
+            __DIR__ . '/../../Classes',
+            __DIR__ . '/../../Tests',
+            __DIR__ . '/../../Configuration',
+        ]
+    );
+// Return a Code Sniffing configuration using
+// all sniffers needed for PSR-2
+// and additionally:
+//  - Remove leading slashes in use clauses.
+//  - PHP single-line arrays should not have trailing comma.
+//  - Single-line whitespace before closing semicolon are prohibited.
+//  - Remove unused use statements in the PHP source code
+//  - Ensure Concatenation to have at least one whitespace around
+//  - Remove trailing whitespace at the end of blank lines.
+
+$config = new PhpCsFixer\Config();
+
+return $config
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@DoctrineAnnotation' => true,
+        '@PSR2' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'blank_line_after_opening_tag' => true,
+        'braces' => ['allow_single_line_closure' => true],
+        'cast_spaces' => ['space' => 'none'],
+        'compact_nullable_typehint' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'declare_equal_normalize' => ['space' => 'none'],
+        'dir_constant' => true,
+        'function_to_constant' => ['functions' => ['get_called_class', 'get_class', 'get_class_this', 'php_sapi_name', 'phpversion', 'pi']],
+        'function_typehint_space' => true,
+        'lowercase_cast' => true,
+        'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
+        'modernize_strpos' => false, // different to https://github.com/TYPO3/typo3/blob/main/Build/php-cs-fixer.php
+        'modernize_types_casting' => true,
+        'native_function_casing' => true,
+        'new_with_braces' => true,
+        'no_alias_functions' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'no_empty_phpdoc' => true,
+        'no_empty_statement' => true,
+        'no_extra_blank_lines' => true,
+        'no_leading_import_slash' => true,
+        'no_leading_namespace_whitespace' => true,
+        'no_null_property_initialization' => false, // different to https://github.com/TYPO3/typo3/blob/main/Build/php-cs-fixer.php
+        'no_short_bool_cast' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_superfluous_elseif' => true,
+        'no_trailing_comma_in_singleline_array' => true,
+        'no_unneeded_control_parentheses' => true,
+        'no_unused_imports' => true,
+        'no_useless_else' => true,
+        'no_whitespace_in_blank_line' => true,
+        'ordered_imports' => true,
+        'php_unit_construct' => ['assertions' => ['assertEquals', 'assertSame', 'assertNotEquals', 'assertNotSame']],
+        'php_unit_mock_short_will_return' => true,
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
+        'phpdoc_no_access' => true,
+        'phpdoc_no_empty_return' => false, // different to https://github.com/TYPO3/typo3/blob/main/Build/php-cs-fixer.php
+        'phpdoc_no_package' => true,
+        'phpdoc_scalar' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_types' => true,
+        'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
+        'return_type_declaration' => ['space_before' => 'none'],
+        'single_quote' => true,
+        'single_line_comment_style' => ['comment_types' => ['hash']],
+        'single_trait_insert_per_statement' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+        'whitespace_after_comma_in_array' => true,
+        'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
+    ])->setFinder($finder);

--- a/.project/tests/phpstan-baseline.neon
+++ b/.project/tests/phpstan-baseline.neon
@@ -1,0 +1,6 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Static method In2code\\\\PowermailCleaner\\\\Service\\\\TimeCalculationService\\:\\:getTodaysStart\\(\\) is unused\\.$#"
+			count: 1
+			path: ../../Classes/Service/TimeCalculationService.php

--- a/.project/tests/phpstan.neon
+++ b/.project/tests/phpstan.neon
@@ -1,0 +1,14 @@
+# tests for v12
+# todo
+# - some phpstan tests will fail due to classes being XCLASSed and the code using the original class, can be explicitly
+#   defined using @var, see Command/CleanupCommand.php
+includes:
+    - phpstan-baseline.neon
+parameters:
+    level: 5
+    tmpDir: ../../.build/var/cache/phpstan
+    paths:
+        - ../../Classes
+    scanDirectories:
+        - ../../.build/vendor/in2code/powermail
+        - ../../.build/vendor/typo3

--- a/Classes/Command/CleanupCommand.php
+++ b/Classes/Command/CleanupCommand.php
@@ -25,6 +25,7 @@ class CleanupCommand extends Command
     }
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var \In2code\PowermailCleaner\Domain\Repository\MailRepository $mailRepository */
         $mailRepository = GeneralUtility::makeInstance(MailRepository::class);
         $mailsToDelete = $mailRepository->findAllDeletionTimeStampOlderThan(time());
         $mails = 0;

--- a/Classes/Command/ForceCleanupCommand.php
+++ b/Classes/Command/ForceCleanupCommand.php
@@ -32,6 +32,7 @@ class ForceCleanupCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var \In2code\PowermailCleaner\Domain\Repository\MailRepository $mailRepository */
         $mailRepository = GeneralUtility::makeInstance(MailRepository::class);
         // ToDo: calculate timestamp
         $timestamp = (time() - $input->getArgument('Retention days') * 86400);

--- a/Classes/Command/InformReceiversCommand.php
+++ b/Classes/Command/InformReceiversCommand.php
@@ -41,11 +41,8 @@ class InformReceiversCommand extends Command
     ) {
         parent::__construct();
         $this->powermailCleanerTyposcript = $this->getTypoScriptConfiguration();
-        /** @var MailRepository $mailRepository */
         $this->mailRepository = GeneralUtility::makeInstance(MailRepository::class);
-        /** @var FlexFormService $flexFormService */
         $this->flexFormService = GeneralUtility::makeInstance(FlexFormService::class);
-        /** @var Mail $mail */
         $this->mail = GeneralUtility::makeInstance(Mail::class);
         $this->timeCalculationService = GeneralUtility::makeInstance(TimeCalculationService::class);
     }
@@ -119,7 +116,7 @@ class InformReceiversCommand extends Command
 
     private function findReceivers(array $flexform): array
     {
-        /** @var  ReceiverAddressService $receiverService */
+        /** @var  ReceiverAddressService $addressService */
         $addressService = GeneralUtility::makeInstance(ReceiverAddressService::class, $this->mail, $flexform);
         return $addressService->getReceiverEmails();
     }

--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -12,15 +12,11 @@ use TYPO3\CMS\Backend\Utility\BackendUtility;
  */
 class ModuleController extends \In2code\Powermail\Controller\ModuleController
 {
-    /**
-     * @param int $age
-     * @param int $pid
-     */
     public function cleanupAction(): ResponseInterface
     {
         $age = null;
         $pid = null;
-        
+
         if ($this->request->hasArgument('age')) {
             $age = $this->request->getArgument('age');
         }

--- a/Classes/Domain/Repository/MailRepository.php
+++ b/Classes/Domain/Repository/MailRepository.php
@@ -155,7 +155,7 @@ class MailRepository extends \In2code\Powermail\Domain\Repository\MailRepository
 
     /**
      * @param int $mailIdentifier
-     * @return QueryBuilder
+     * @return array
      * @throws Exception
      */
     public function getAnswersWithFiles(int $mailIdentifier): array

--- a/Classes/Service/TimeCalculationService.php
+++ b/Classes/Service/TimeCalculationService.php
@@ -15,6 +15,9 @@ class TimeCalculationService
         return $notificationLimit;
     }
 
+    /**
+     * @todo Remove? Is not used
+     */
     private static function getTodaysStart(): int
     {
         return strtotime('today', time());

--- a/Classes/Utility/FileUtility.php
+++ b/Classes/Utility/FileUtility.php
@@ -80,6 +80,7 @@ class FileUtility
 
     public static function deleteFromFilesystem(string $identifier, ?ResourceStorage $storage): void
     {
+        $resourceBasePath = '';
         if ($storage instanceof ResourceStorage) {
             $resourceBasePath = $storage->getConfiguration()['basePath'];
         }

--- a/composer.json
+++ b/composer.json
@@ -81,14 +81,10 @@
     "friends-of-behat/mink-extension": "^2.7",
     "behat/mink-selenium2-driver": "^1.7",
     "friends-of-behat/mink-browserkit-driver": "^1.6",
-    "drevops/behat-screenshot": "^1.2"
+    "drevops/behat-screenshot": "^1.2",
+    "phpstan/phpstan": "^1.11.7",
+    "saschaegerer/phpstan-typo3": "^1.10.2"
   },
-  "repositories": [
-    {
-      "type": "git",
-      "url": "git@github.com:in2code-pro/powermail.git"
-    }
-  ],
   "autoload": {
     "psr-4": {
       "In2code\\PowermailCleaner\\": "Classes/"
@@ -122,8 +118,11 @@
     "test:behaviour": "behat --config Tests/Behavior/behat.ddev.yml",
     "test:behaviour:tag": "behat --config Tests/Behavior/behat.ddev.yml --tags",
     "test:behaviour:stop": "behat --config Tests/Behavior/behat.ddev.yml --stop-on-failure",
-    "test:php:cs": ".Build/bin/php-cs-fixer --version && .Build/bin/php-cs-fixer fix --dry-run --config=.project/tests/.php-cs-fixer.php --diff",
+    "test:php:cs": ".build/bin/php-cs-fixer --version && .build/bin/php-cs-fixer fix --dry-run --config=.project/tests/.php-cs-fixer.php --diff",
+    "fix:php:cs": ".build/bin/php-cs-fixer --version && .build/bin/php-cs-fixer fix --config=.project/tests/.php-cs-fixer.php --diff",
     "test:php:lint": "find *.php Classes Configuration Tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
+    "test:php:phpstan": "phpstan analyse -c .project/tests/phpstan.neon",
+    "test:php:phpstan:generate-baseline": "phpstan analyse -c .project/tests/phpstan.neon --generate-baseline .project/tests/phpstan-baseline.neon",
     "test:typoscript:lint": "typoscript-lint --config=.project/tests/typoscript-lint.yml",
     "test:unit": "phpunit -c phpunit.xml.dist"
   }


### PR DESCRIPTION
**Additional notes**: This is a proposal for getting checks via GitHub started. I think for contribution having common cgl styles applied to files would be helpful. The phpstan checks did not find anything problematic (level 5), but might be helpful in the future.

Please feel free to reject and close or request changes.

The php-cs-fixer is currently commented out in .github/workflows/testing.yaml since it will result in several .php files to be change. Can be added later.

-----

Add some checks and tests (in particular php-cs-fixer, phpstan) which were partially already defined in composer.json, but some pieces were missing

- remove repository for powermail "pro" from composer.json because it will prevent "composer install" from working without credentials and is not need currently for v12. (Alternatively, the repository could be kept there and removed in th GitHub job using (must add key first in compsoer.json):

composer config --unset repositories.powermail_pro

- copy .project/tests/.php-cs-fixer.php from powermail repo (v12)
- add php-cs-fixer as dev requiredment
- copy .github/workflow/testing.yaml from powermail repo (v12)
- use .build instead of .Build in scripts (since that is what is being used, also corresponds to powermail)
- add phpstan, copy config from powermail and modify
- add "fix:php:cs" for fixing cgl
- fix some phpstan warnings
- add files for testing to .gitattributes (export-ignore)



